### PR TITLE
fix: Remove Extra "Close" Button from Saved Memory Modal

### DIFF
--- a/app/chatpage.tsx
+++ b/app/chatpage.tsx
@@ -148,11 +148,6 @@ function ChatPage({ user }: { user: Session | null }) {
                       </form>
                     </ul>
                   </CredenzaBody>
-                  <CredenzaFooter>
-                    <CredenzaClose asChild>
-                      <button>Close</button>
-                    </CredenzaClose>
-                  </CredenzaFooter>
                 </CredenzaContent>
               </Credenza>
             )}


### PR DESCRIPTION
# Fix: Remove Redundant "Close" Button from Saved Memory Modal

## Overview
This pull request addresses a UI redundancy in the Saved Memory modal by removing an unnecessary "Close" button.

## Changes
- **Key Changes:** Removed the "Close" button from the Saved Memory modal, leaving only the 'X' button for closing the modal.
- **New Features:** None
- **Refactoring:** None

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
## Description
This PR addresses the issue of an extra "Close" button in the Saved Memory modal. The modal previously had both an 'X' button in the top-right corner and a "Close" button, which was redundant. This update removes the unnecessary "Close" button, leaving only the 'X' button for closing the modal.

## Changes Made
- Removed the "Close" button from the Saved Memory modal.

## Screenshots
**Before:**
![image](https://github.com/user-attachments/assets/2975e775-8aeb-48cc-b228-d14a71e04d23)

**After:**
![image](https://github.com/user-attachments/assets/8dd26eb7-b65e-49fc-865a-fcffe9a30eaf)

## Related Issue
Closes #14 
</details>

