### PR TITLE
Show latency disclaimers and display only memory titles

### DIFF
--- a/app/Globe.tsx
+++ b/app/Globe.tsx
@@ -37,7 +37,7 @@ function Globe() {
         // Called on every animation frame.
         // `state` will be an empty object, return updated params.
         state.phi = phi;
-        phi += 0.01;
+        phi += 0.0035;
       },
     });
 

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -56,8 +56,8 @@ export const getMemories = async (user: Session | null) => {
 				const memoryFull = await supermemory.memories.get(memory.id);
 				return {
 					memory:
+            memoryFull.title ??
 						memoryFull.summary ??
-						memory.title ??
 						memoryFull.content ??
 						"No memory content",
 					id: memory.id,

--- a/app/chatpage.tsx
+++ b/app/chatpage.tsx
@@ -47,6 +47,7 @@ function ChatPage({ user }: { user: Session | null }) {
 
   const [customUserMemory, setCustomUserMemory] = useState<string | null>(null);
   const [isMemoriesModalOpen, setIsMemoriesModalOpen] = useState(false);
+  const [showMemoryDisclaimer, setShowMemoryDisclaimer] = useState(false);
 
   // React Query hooks
   const { data: userMemories = [], refetch: refetchMemories } = useMemories(user);
@@ -61,6 +62,11 @@ function ChatPage({ user }: { user: Session | null }) {
     createMemoryMutation.mutate(customUserMemory, {
       onSuccess: () => {
         setCustomUserMemory(null);
+        setShowMemoryDisclaimer(true);
+        // Hide disclaimer after 10 seconds
+        setTimeout(() => {
+          setShowMemoryDisclaimer(false);
+        }, 10000);
       },
       onError: (error) => {
         console.error('Error creating memory:', error);
@@ -197,7 +203,12 @@ function ChatPage({ user }: { user: Session | null }) {
 
             <div className='flex gap-4 items-center'>
               {user?.user && (
-                <Credenza open={isMemoriesModalOpen} onOpenChange={setIsMemoriesModalOpen}>
+                <Credenza open={isMemoriesModalOpen} onOpenChange={(open) => {
+                  setIsMemoriesModalOpen(open);
+                  if (!open) {
+                    setShowMemoryDisclaimer(false);
+                  }
+                }}>
                   <CredenzaTrigger asChild>
                     <button
                       onClick={() => {
@@ -215,11 +226,21 @@ function ChatPage({ user }: { user: Session | null }) {
                         Your Memories
                       </CredenzaTitle>
                       <CredenzaDescription>
-                        Information automatically collected about you by mem0.ai
+                        Memories collected from your searches and custom notes
                       </CredenzaDescription>
                     </CredenzaHeader>
                     <CredenzaBody>
                       <ul className="list-disc max-h-96 overflow-y-auto flex flex-col gap-2">
+                        {showMemoryDisclaimer && (
+                          <div className="bg-blue-50 border border-blue-200 rounded-md p-3 mb-2 text-sm text-blue-700">
+                            <p className="flex items-center gap-2">
+                              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
+                                <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clipRule="evenodd" />
+                              </svg>
+                              Memories may take up to a minute to be fully processed.
+                            </p>
+                          </div>
+                        )}
                         {userMemories?.length === 0 && (
                           <li>
                             Nothing here... Yet! Just start browsing and asking

--- a/app/chatpage.tsx
+++ b/app/chatpage.tsx
@@ -48,9 +48,10 @@ function ChatPage({ user }: { user: Session | null }) {
   const [customUserMemory, setCustomUserMemory] = useState<string | null>(null);
   const [isMemoriesModalOpen, setIsMemoriesModalOpen] = useState(false);
   const [showMemoryDisclaimer, setShowMemoryDisclaimer] = useState(false);
+  const [showDeletionDisclaimer, setShowDeletionDisclaimer] = useState(false);
 
   // React Query hooks
-  const { data: userMemories = [], refetch: refetchMemories } = useMemories(user);
+  const { data: userMemories = [], refetch: refetchMemories, isLoading: isLoadingMemories } = useMemories(user);
   const deleteMemoryMutation = useDeleteMemory(user);
   const createMemoryMutation = useCreateMemory(user);
 
@@ -62,6 +63,7 @@ function ChatPage({ user }: { user: Session | null }) {
     createMemoryMutation.mutate(customUserMemory, {
       onSuccess: () => {
         setCustomUserMemory(null);
+        setShowDeletionDisclaimer(false); // Hide deletion disclaimer if showing
         setShowMemoryDisclaimer(true);
         // Hide disclaimer after 10 seconds
         setTimeout(() => {
@@ -75,7 +77,16 @@ function ChatPage({ user }: { user: Session | null }) {
   };
 
   const handleDeleteMemory = (memoryId: string) => {
-    deleteMemoryMutation.mutate(memoryId);
+    deleteMemoryMutation.mutate(memoryId, {
+      onSuccess: () => {
+        setShowMemoryDisclaimer(false); // Hide add disclaimer if showing
+        setShowDeletionDisclaimer(true);
+        // Hide disclaimer after 10 seconds
+        setTimeout(() => {
+          setShowDeletionDisclaimer(false);
+        }, 10000);
+      }
+    });
   };
 
   const fetchSearch = async (
@@ -207,6 +218,7 @@ function ChatPage({ user }: { user: Session | null }) {
                   setIsMemoriesModalOpen(open);
                   if (!open) {
                     setShowMemoryDisclaimer(false);
+                    setShowDeletionDisclaimer(false);
                   }
                 }}>
                   <CredenzaTrigger asChild>
@@ -241,38 +253,54 @@ function ChatPage({ user }: { user: Session | null }) {
                             </p>
                           </div>
                         )}
-                        {userMemories?.length === 0 && (
-                          <li>
+                        {showDeletionDisclaimer && (
+                          <div className="bg-yellow-50 border border-yellow-200 rounded-md p-3 mb-2 text-sm text-yellow-700">
+                            <p className="flex items-center gap-2">
+                              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
+                                <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
+                              </svg>
+                              Deletions may take up to 30 seconds to process.
+                            </p>
+                          </div>
+                        )}
+                        {isLoadingMemories ? (
+                          <div className="flex items-center justify-center py-8">
+                            <LoadingSpinner />
+                            <span className="ml-2">Loading memories...</span>
+                          </div>
+                        ) : userMemories?.length === 0 ? (
+                          <li className="text-center py-4">
                             Nothing here... Yet! Just start browsing and asking
                             questions. I&apos;ll remember it.
                           </li>
-                        )}
-                        {userMemories?.map((memory) => (
-                          <li
-                            key={memory.id}
-                            className="text-sm border rounded-md p-2 flex gap-2 justify-between"
-                          >
-                            <span>{memory.memory}</span>
-                            <button
-                              onClick={() => handleDeleteMemory(memory.id)}
-                              disabled={deleteMemoryMutation.isPending}
-                              className={deleteMemoryMutation.isPending ? 'opacity-50' : ''}
+                        ) : (
+                          userMemories?.map((memory) => (
+                            <li
+                              key={memory.id}
+                              className="text-sm border rounded-md p-2 flex gap-2 justify-between"
                             >
-                              <svg
-                                xmlns="http://www.w3.org/2000/svg"
-                                viewBox="0 0 20 20"
-                                fill="currentColor"
-                                className="size-5"
+                              <span>{memory.memory}</span>
+                              <button
+                                onClick={() => handleDeleteMemory(memory.id)}
+                                disabled={deleteMemoryMutation.isPending}
+                                className={deleteMemoryMutation.isPending ? 'opacity-50' : ''}
                               >
-                                <path
-                                  fillRule="evenodd"
-                                  d="M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4ZM8.58 7.72a.75.75 0 0 0-1.5.06l.3 7.5a.75.75 0 1 0 1.5-.06l-.3-7.5Zm4.34.06a.75.75 0 1 0-1.5-.06l-.3 7.5a.75.75 0 1 0 1.5.06l.3-7.5Z"
-                                  clipRule="evenodd"
-                                />
-                              </svg>
-                            </button>
-                          </li>
-                        ))}
+                                <svg
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  viewBox="0 0 20 20"
+                                  fill="currentColor"
+                                  className="size-5"
+                                >
+                                  <path
+                                    fillRule="evenodd"
+                                    d="M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4ZM8.58 7.72a.75.75 0 0 0-1.5.06l.3 7.5a.75.75 0 1 0 1.5-.06l-.3-7.5Zm4.34.06a.75.75 0 1 0-1.5-.06l-.3 7.5a.75.75 0 1 0 1.5.06l.3-7.5Z"
+                                    clipRule="evenodd"
+                                  />
+                                </svg>
+                              </button>
+                            </li>
+                          ))
+                        )}
                         <form
                           onSubmit={handleMemorySubmit}
                           className="flex justify-between items-center gap-2"
@@ -299,9 +327,10 @@ function ChatPage({ user }: { user: Session | null }) {
               )}
               <a
                 href="https://github.com/supermemoryai/opensearch-ai"
-                className="flex max-lg:hidden items-center justify-between gap-4 border-b border-gray-300 pb-6 pt-4 lg:static lg:w-auto lg:border-none lg:bg-transparent lg:p-0"
+                className="flex max-lg:hidden items-center gap-4
+                 py-4 lg:static lg:w-auto"
               >
-                Github{' '}
+                <span>Github</span>
                 <svg
                   viewBox="0 0 256 250"
                   width="20"

--- a/app/chatpage.tsx
+++ b/app/chatpage.tsx
@@ -5,7 +5,6 @@ import React, { useEffect, useRef, useState, FormEvent } from 'react';
 import Blobs from './Blobs';
 import Globe from './Globe';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 import logo from './assets/logo.svg';
 import { Session } from 'next-auth';
 import { signIn } from 'next-auth/react';
@@ -125,8 +124,6 @@ function ChatPage({ user }: { user: Session | null }) {
       }
     }
   }, [initialQuery]);
-
-  const router = useRouter();
 
   // Loading spinner component
   const LoadingSpinner = () => (


### PR DESCRIPTION
This PR makes a few small UX tweaks:
- Slows down the globe. I thought it was too fast.
- Adds disclaimers about latency to the Saved Memories modal when adding and deleting memories
- Displays memory titles instead of summaries (No more repeated "This document contains...")

Nothing breaking, just polishing things up.